### PR TITLE
Add basic user and admin authentication with dashboards

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class AdminController extends Controller
+{
+    /**
+     * Show the admin login form.
+     */
+    public function showLogin()
+    {
+        return view('admin.login');
+    }
+
+    /**
+     * Handle an incoming admin authentication request.
+     */
+    public function login(Request $request)
+    {
+        $credentials = $request->only('email', 'password');
+
+        if ($credentials['email'] === 'admin@email.com' && $credentials['password'] === '123456') {
+            $request->session()->put('admin_authenticated', true);
+            return redirect()->route('admin.dashboard');
+        }
+
+        return back()->withErrors([
+            'email' => 'Invalid credentials.',
+        ]);
+    }
+
+    /**
+     * Display the admin dashboard if authenticated.
+     */
+    public function dashboard(Request $request)
+    {
+        if (!$request->session()->get('admin_authenticated')) {
+            return redirect()->route('admin.login');
+        }
+
+        return view('admin.dashboard');
+    }
+
+    /**
+     * Log the admin out of the application.
+     */
+    public function logout(Request $request)
+    {
+        $request->session()->forget('admin_authenticated');
+        return redirect()->route('admin.login');
+    }
+}

--- a/resources/views/admin/dashboard.blade.php
+++ b/resources/views/admin/dashboard.blade.php
@@ -1,0 +1,17 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Admin Dashboard') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 bg-white border-b border-gray-200">
+                    You're logged in as admin!
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/admin/login.blade.php
+++ b/resources/views/admin/login.blade.php
@@ -1,0 +1,31 @@
+<x-guest-layout>
+    <x-auth-card>
+        <x-slot name="logo">
+            <a href="/">
+                <x-application-logo class="w-20 h-20 fill-current text-gray-500" />
+            </a>
+        </x-slot>
+
+        <x-auth-validation-errors class="mb-4" :errors="$errors" />
+
+        <form method="POST" action="{{ url('/admin/login') }}">
+            @csrf
+
+            <div>
+                <x-label for="email" :value="__('Email')" />
+                <x-input id="email" class="block mt-1 w-full" type="email" name="email" required autofocus />
+            </div>
+
+            <div class="mt-4">
+                <x-label for="password" :value="__('Password')" />
+                <x-input id="password" class="block mt-1 w-full" type="password" name="password" required />
+            </div>
+
+            <div class="flex items-center justify-end mt-4">
+                <x-button class="ml-3">
+                    {{ __('Log in') }}
+                </x-button>
+            </div>
+        </form>
+    </x-auth-card>
+</x-guest-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\AdminController;
 
 /*
 |--------------------------------------------------------------------------
@@ -12,6 +13,20 @@ use Illuminate\Support\Facades\Route;
 | contains the "web" middleware group. Now create something great!
 |
 */
+
+Route::view('/register', 'auth.register')->middleware('guest');
+Route::view('/login', 'auth.login')->middleware('guest');
+
+Route::get('/dashboard', function () {
+    return view('dashboard');
+})->middleware(['auth'])->name('dashboard');
+
+Route::prefix('admin')->group(function () {
+    Route::get('/login', [AdminController::class, 'showLogin'])->name('admin.login');
+    Route::post('/login', [AdminController::class, 'login']);
+    Route::get('/dashboard', [AdminController::class, 'dashboard'])->name('admin.dashboard');
+    Route::post('/logout', [AdminController::class, 'logout'])->name('admin.logout');
+});
 
 Route::get('/', function () {
     return ['Laravel' => app()->version()];


### PR DESCRIPTION
## Summary
- allow users to access login/registration pages and a protected dashboard
- add simple admin authentication with hard coded credentials
- create blade views for admin login and dashboard

## Testing
- `composer install` (fails: package requirements / GitHub token)
- `./vendor/bin/phpunit` (fails: No such file or directory)


------
https://chatgpt.com/codex/tasks/task_b_68af411566a0832d8311dfaeaf6e7c34