### PR TITLE
Link asset templates to Laravel welcome page

### DIFF
--- a/resources/views/layouts/front.blade.php
+++ b/resources/views/layouts/front.blade.php
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>@yield('title', config('app.name'))</title>
+    <link rel="stylesheet" href="{{ asset('assets/css/bootstrap.min.css') }}">
+    <link rel="stylesheet" href="{{ asset('assets/css/animate.css') }}">
+    <link rel="stylesheet" href="{{ asset('assets/css/style.css') }}">
+    <link rel="stylesheet" href="{{ asset('assets/css/responsive.css') }}">
+</head>
+<body>
+    @yield('content')
+
+    <script src="{{ asset('assets/js/vendor/jquery-3.6.2.min.js') }}"></script>
+    <script src="{{ asset('assets/js/bootstrap.min.js') }}"></script>
+    <script src="{{ asset('assets/js/script.js') }}"></script>
+</body>
+</html>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -1,0 +1,23 @@
+@extends('layouts.front')
+
+@section('title', 'Welcome')
+
+@section('content')
+<header class="header-area">
+    <div class="container">
+        <div class="header-menu">
+            <ul>
+                <li><a href="#">Home</a></li>
+                <li><a href="#">About</a></li>
+                <li><a href="#">Contact</a></li>
+            </ul>
+        </div>
+    </div>
+</header>
+<section class="hero-section text-center py-5">
+    <div class="container">
+        <h1>Welcome</h1>
+        <p class="lead">This page uses template assets.</p>
+    </div>
+</section>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -28,8 +28,6 @@ Route::prefix('admin')->group(function () {
     Route::post('/logout', [AdminController::class, 'logout'])->name('admin.logout');
 });
 
-Route::get('/', function () {
-    return ['Laravel' => app()->version()];
-});
+Route::view('/', 'welcome');
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
## Summary
- Use public template assets in a new layout
- Add styled welcome page that uses the template design
- Route the application root to the new welcome page

## Testing
- `./vendor/bin/phpunit` *(fails: No such file or directory)*
- `composer install` *(fails: required PHP version < 8.3)*

------
https://chatgpt.com/codex/tasks/task_b_68afd2795db0832d8c3187b4019b2340