### PR TITLE
Add Bootstrap-based auth pages for users and admins

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -15,13 +15,41 @@ class AdminController extends Controller
     }
 
     /**
+     * Show the admin registration form.
+     */
+    public function showRegister()
+    {
+        return view('admin.register');
+    }
+
+    /**
+     * Handle an incoming admin registration request.
+     */
+    public function register(Request $request)
+    {
+        $validated = $request->validate([
+            'email' => 'required|email',
+            'password' => 'required|min:6',
+        ]);
+
+        $request->session()->put('admin_credentials', $validated);
+
+        return redirect()->route('admin.login')->with('status', 'Registration successful. Please log in.');
+    }
+
+    /**
      * Handle an incoming admin authentication request.
      */
     public function login(Request $request)
     {
         $credentials = $request->only('email', 'password');
 
-        if ($credentials['email'] === 'admin@email.com' && $credentials['password'] === '123456') {
+        $admin = $request->session()->get('admin_credentials', [
+            'email' => 'admin@email.com',
+            'password' => '123456',
+        ]);
+
+        if ($credentials['email'] === $admin['email'] && $credentials['password'] === $admin['password']) {
             $request->session()->put('admin_authenticated', true);
             return redirect()->route('admin.dashboard');
         }

--- a/public/assets/css/auth.css
+++ b/public/assets/css/auth.css
@@ -1,0 +1,8 @@
+.form-container {
+    max-width: 400px;
+    margin: 50px auto;
+    padding: 2rem;
+    background: #ffffff;
+    border-radius: 8px;
+    box-shadow: 0 0 10px rgba(0,0,0,0.1);
+}

--- a/resources/views/admin/register.blade.php
+++ b/resources/views/admin/register.blade.php
@@ -1,5 +1,5 @@
 @extends('layouts.front')
-@section('title','Admin Login')
+@section('title','Admin Register')
 
 @push('styles')
 <link rel="stylesheet" href="{{ asset('assets/css/auth.css') }}">
@@ -8,7 +8,7 @@
 @section('content')
 <div class="container">
     <div class="form-container">
-        <h2 class="mb-4 text-center">Admin Login</h2>
+        <h2 class="mb-4 text-center">Admin Register</h2>
 
         @if ($errors->any())
             <div class="alert alert-danger">
@@ -20,7 +20,7 @@
             </div>
         @endif
 
-        <form method="POST" action="{{ url('/admin/login') }}">
+        <form method="POST" action="{{ url('/admin/register') }}">
             @csrf
             <div class="mb-3">
                 <label for="email" class="form-label">Email</label>
@@ -31,7 +31,7 @@
                 <input id="password" class="form-control" type="password" name="password" required>
             </div>
             <div class="d-flex justify-content-end">
-                <button class="btn btn-primary" type="submit">Log in</button>
+                <button class="btn btn-primary" type="submit">Register</button>
             </div>
         </form>
     </div>

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -1,56 +1,50 @@
-<x-guest-layout>
-    <x-auth-card>
-        <x-slot name="logo">
-            <a href="/">
-                <x-application-logo class="w-20 h-20 fill-current text-gray-500" />
-            </a>
-        </x-slot>
+@extends('layouts.front')
+@section('title', 'User Login')
 
-        <!-- Session Status -->
-        <x-auth-session-status class="mb-4" :status="session('status')" />
+@push('styles')
+<link rel="stylesheet" href="{{ asset('assets/css/auth.css') }}">
+@endpush
 
-        <!-- Validation Errors -->
-        <x-auth-validation-errors class="mb-4" :errors="$errors" />
+@section('content')
+<div class="container">
+    <div class="form-container">
+        <h2 class="mb-4 text-center">User Login</h2>
+
+        @if (session('status'))
+            <div class="alert alert-success">{{ session('status') }}</div>
+        @endif
+
+        @if ($errors->any())
+            <div class="alert alert-danger">
+                <ul class="mb-0">
+                    @foreach ($errors->all() as $error)
+                        <li>{{ $error }}</li>
+                    @endforeach
+                </ul>
+            </div>
+        @endif
 
         <form method="POST" action="{{ route('login') }}">
             @csrf
-
-            <!-- Email Address -->
-            <div>
-                <x-label for="email" :value="__('Email')" />
-
-                <x-input id="email" class="block mt-1 w-full" type="email" name="email" :value="old('email')" required autofocus />
+            <div class="mb-3">
+                <label for="email" class="form-label">Email</label>
+                <input id="email" class="form-control" type="email" name="email" value="{{ old('email') }}" required autofocus>
             </div>
-
-            <!-- Password -->
-            <div class="mt-4">
-                <x-label for="password" :value="__('Password')" />
-
-                <x-input id="password" class="block mt-1 w-full"
-                                type="password"
-                                name="password"
-                                required autocomplete="current-password" />
+            <div class="mb-3">
+                <label for="password" class="form-label">Password</label>
+                <input id="password" class="form-control" type="password" name="password" required autocomplete="current-password">
             </div>
-
-            <!-- Remember Me -->
-            <div class="block mt-4">
-                <label for="remember_me" class="inline-flex items-center">
-                    <input id="remember_me" type="checkbox" class="rounded border-gray-300 text-indigo-600 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50" name="remember">
-                    <span class="ml-2 text-sm text-gray-600">{{ __('Remember me') }}</span>
-                </label>
+            <div class="mb-3 form-check">
+                <input id="remember" type="checkbox" class="form-check-input" name="remember">
+                <label class="form-check-label" for="remember">Remember me</label>
             </div>
-
-            <div class="flex items-center justify-end mt-4">
+            <div class="d-flex justify-content-between align-items-center">
                 @if (Route::has('password.request'))
-                    <a class="underline text-sm text-gray-600 hover:text-gray-900" href="{{ route('password.request') }}">
-                        {{ __('Forgot your password?') }}
-                    </a>
+                    <a href="{{ route('password.request') }}">Forgot your password?</a>
                 @endif
-
-                <x-button class="ml-3">
-                    {{ __('Log in') }}
-                </x-button>
+                <button class="btn btn-primary" type="submit">Log in</button>
             </div>
         </form>
-    </x-auth-card>
-</x-guest-layout>
+    </div>
+</div>
+@endsection

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -1,59 +1,49 @@
-<x-guest-layout>
-    <x-auth-card>
-        <x-slot name="logo">
-            <a href="/">
-                <x-application-logo class="w-20 h-20 fill-current text-gray-500" />
-            </a>
-        </x-slot>
+@extends('layouts.front')
+@section('title', 'User Register')
 
-        <!-- Validation Errors -->
-        <x-auth-validation-errors class="mb-4" :errors="$errors" />
+@push('styles')
+<link rel="stylesheet" href="{{ asset('assets/css/auth.css') }}">
+@endpush
+
+@section('content')
+<div class="container">
+    <div class="form-container">
+        <h2 class="mb-4 text-center">User Register</h2>
+
+        @if ($errors->any())
+            <div class="alert alert-danger">
+                <ul class="mb-0">
+                    @foreach ($errors->all() as $error)
+                        <li>{{ $error }}</li>
+                    @endforeach
+                </ul>
+            </div>
+        @endif
 
         <form method="POST" action="{{ route('register') }}">
             @csrf
-
-            <!-- Name -->
-            <div>
-                <x-label for="name" :value="__('Name')" />
-
-                <x-input id="name" class="block mt-1 w-full" type="text" name="name" :value="old('name')" required autofocus />
+            <div class="mb-3">
+                <label for="name" class="form-label">Name</label>
+                <input id="name" class="form-control" type="text" name="name" value="{{ old('name') }}" required autofocus>
             </div>
-
-            <!-- Email Address -->
-            <div class="mt-4">
-                <x-label for="email" :value="__('Email')" />
-
-                <x-input id="email" class="block mt-1 w-full" type="email" name="email" :value="old('email')" required />
+            <div class="mb-3">
+                <label for="email" class="form-label">Email</label>
+                <input id="email" class="form-control" type="email" name="email" value="{{ old('email') }}" required>
             </div>
-
-            <!-- Password -->
-            <div class="mt-4">
-                <x-label for="password" :value="__('Password')" />
-
-                <x-input id="password" class="block mt-1 w-full"
-                                type="password"
-                                name="password"
-                                required autocomplete="new-password" />
+            <div class="mb-3">
+                <label for="password" class="form-label">Password</label>
+                <input id="password" class="form-control" type="password" name="password" required autocomplete="new-password">
             </div>
-
-            <!-- Confirm Password -->
-            <div class="mt-4">
-                <x-label for="password_confirmation" :value="__('Confirm Password')" />
-
-                <x-input id="password_confirmation" class="block mt-1 w-full"
-                                type="password"
-                                name="password_confirmation" required />
+            <div class="mb-3">
+                <label for="password_confirmation" class="form-label">Confirm Password</label>
+                <input id="password_confirmation" class="form-control" type="password" name="password_confirmation" required>
             </div>
-
-            <div class="flex items-center justify-end mt-4">
-                <a class="underline text-sm text-gray-600 hover:text-gray-900" href="{{ route('login') }}">
-                    {{ __('Already registered?') }}
-                </a>
-
-                <x-button class="ml-4">
-                    {{ __('Register') }}
-                </x-button>
+            <div class="d-flex justify-content-between align-items-center">
+                <a href="{{ route('login') }}">Already registered?</a>
+                <button class="btn btn-primary" type="submit">Register</button>
             </div>
         </form>
-    </x-auth-card>
-</x-guest-layout>
+    </div>
+</div>
+@endsection
+

--- a/resources/views/layouts/front.blade.php
+++ b/resources/views/layouts/front.blade.php
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="{{ asset('assets/css/animate.css') }}">
     <link rel="stylesheet" href="{{ asset('assets/css/style.css') }}">
     <link rel="stylesheet" href="{{ asset('assets/css/responsive.css') }}">
+    @stack('styles')
 </head>
 <body>
     @yield('content')
@@ -15,5 +16,6 @@
     <script src="{{ asset('assets/js/vendor/jquery-3.6.2.min.js') }}"></script>
     <script src="{{ asset('assets/js/bootstrap.min.js') }}"></script>
     <script src="{{ asset('assets/js/script.js') }}"></script>
+    @stack('scripts')
 </body>
 </html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -24,6 +24,8 @@ Route::get('/dashboard', function () {
 Route::prefix('admin')->group(function () {
     Route::get('/login', [AdminController::class, 'showLogin'])->name('admin.login');
     Route::post('/login', [AdminController::class, 'login']);
+    Route::get('/register', [AdminController::class, 'showRegister'])->name('admin.register');
+    Route::post('/register', [AdminController::class, 'register']);
     Route::get('/dashboard', [AdminController::class, 'dashboard'])->name('admin.dashboard');
     Route::post('/logout', [AdminController::class, 'logout'])->name('admin.logout');
 });


### PR DESCRIPTION
## Summary
- Redesign user login and registration views using front layout and new auth.css styles
- Add admin login and registration pages with session-based credential handling
- Wire up admin register routes and extend controller to support registration

## Testing
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*
- `composer install` *(fails: package version constraints do not allow PHP 8.4)*

------
https://chatgpt.com/codex/tasks/task_b_68afd5077498832dbbac500173bd20ee