### PR TITLE
Add phone field and update admin credentials

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -46,7 +46,7 @@ class AdminController extends Controller
 
         $admin = $request->session()->get('admin_credentials', [
             'email' => 'admin@email.com',
-            'password' => '123456',
+            'password' => '12345678',
         ]);
 
         if ($credentials['email'] === $admin['email'] && $credentials['password'] === $admin['password']) {

--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -26,12 +26,14 @@ class RegisteredUserController extends Controller
             'name' => ['required', 'string', 'max:255'],
             'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],
             'password' => ['required', 'confirmed', Rules\Password::defaults()],
+            'phone' => ['required', 'string', 'max:255'],
         ]);
 
         $user = User::create([
             'name' => $request->name,
             'email' => $request->email,
             'password' => Hash::make($request->password),
+            'phone' => $request->phone,
         ]);
 
         event(new Registered($user));

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -21,6 +21,7 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
+        'phone',
     ];
 
     /**

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -19,6 +19,7 @@ class UserFactory extends Factory
             'email' => $this->faker->unique()->safeEmail(),
             'email_verified_at' => now(),
             'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
+            'phone' => $this->faker->phoneNumber(),
             'remember_token' => Str::random(10),
         ];
     }

--- a/public/assets/css/auth.css
+++ b/public/assets/css/auth.css
@@ -1,8 +1,27 @@
+body {
+    background: linear-gradient(135deg, #f8f9fa, #e9ecef);
+    font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+}
+
 .form-container {
-    max-width: 400px;
-    margin: 50px auto;
-    padding: 2rem;
+    max-width: 450px;
+    margin: 60px auto;
+    padding: 2.5rem;
     background: #ffffff;
-    border-radius: 8px;
-    box-shadow: 0 0 10px rgba(0,0,0,0.1);
+    border-radius: 10px;
+    box-shadow: 0 10px 25px rgba(0,0,0,0.05);
+}
+
+.form-container h2 {
+    font-weight: 600;
+}
+
+.form-container .form-control {
+    border-radius: 6px;
+    box-shadow: none;
+    border-color: #dee2e6;
+}
+
+.form-container .btn-primary {
+    padding: 0.5rem 1.5rem;
 }

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -31,6 +31,10 @@
                 <input id="email" class="form-control" type="email" name="email" value="{{ old('email') }}" required>
             </div>
             <div class="mb-3">
+                <label for="phone" class="form-label">Phone</label>
+                <input id="phone" class="form-control" type="text" name="phone" value="{{ old('phone') }}" required>
+            </div>
+            <div class="mb-3">
                 <label for="password" class="form-label">Password</label>
                 <input id="password" class="form-control" type="password" name="password" required autocomplete="new-password">
             </div>


### PR DESCRIPTION
## Summary
- capture user phone during registration
- set default admin login to admin@email.com / 12345678
- refine auth page styling for a more polished look

## Testing
- `composer install --ignore-platform-reqs` *(fails: GitHub OAuth token required)*

------
https://chatgpt.com/codex/tasks/task_b_68afd73003b4832db471623793fb025c