### PR TITLE
Add basic admin profile page

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -34,7 +34,7 @@ class AdminController extends Controller
 
         $request->session()->put('admin_credentials', $validated);
 
-        return redirect()->route('admin.login')->with('status', 'Registration successful. Please log in.');
+        return redirect()->route('admin.login')->with('status', __('Registration successful. Please log in.'));
     }
 
     /**
@@ -55,7 +55,7 @@ class AdminController extends Controller
         }
 
         return back()->withErrors([
-            'email' => 'Invalid credentials.',
+            'email' => __('Invalid credentials.'),
         ]);
     }
 
@@ -69,6 +69,22 @@ class AdminController extends Controller
         }
 
         return view('admin.dashboard');
+    }
+
+    /**
+     * Display the admin profile if authenticated.
+     */
+    public function profile(Request $request)
+    {
+        if (!$request->session()->get('admin_authenticated')) {
+            return redirect()->route('admin.login');
+        }
+
+        $admin = $request->session()->get('admin_credentials', [
+            'email' => 'admin@email.com',
+        ]);
+
+        return view('admin.profile', ['admin' => $admin]);
     }
 
     /**

--- a/app/Http/Controllers/LanguageController.php
+++ b/app/Http/Controllers/LanguageController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+class LanguageController extends Controller
+{
+    /**
+     * Switch the application language.
+     */
+    public function switch(string $locale, Request $request): RedirectResponse
+    {
+        if (! in_array($locale, ['en', 'bn'])) {
+            abort(400);
+        }
+
+        $request->session()->put('locale', $locale);
+        app()->setLocale($locale);
+
+        return redirect()->back();
+    }
+}

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -38,6 +38,7 @@ class Kernel extends HttpKernel
             \App\Http\Middleware\VerifyCsrfToken::class,
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
             \App\Http\Middleware\HandleInertiaRequests::class,
+            \App\Http\Middleware\SetLocale::class,
         ],
 
         'api' => [

--- a/app/Http/Middleware/SetLocale.php
+++ b/app/Http/Middleware/SetLocale.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+
+class SetLocale
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        $locale = $request->session()->get('locale', config('app.locale'));
+        app()->setLocale($locale);
+
+        return $next($request);
+    }
+}

--- a/resources/lang/bn.json
+++ b/resources/lang/bn.json
@@ -1,0 +1,16 @@
+{
+    "Admin Login": "অ্যাডমিন লগইন",
+    "Email": "ইমেইল",
+    "Password": "পাসওয়ার্ড",
+    "Log in": "লগইন",
+    "Admin Register": "অ্যাডমিন রেজিস্টার",
+    "Register": "রেজিস্টার",
+    "Admin Dashboard": "অ্যাডমিন ড্যাশবোর্ড",
+    "You're logged in as admin!": "আপনি অ্যাডমিন হিসেবে লগইন করেছেন!",
+    "View Profile": "প্রোফাইল দেখুন",
+    "Admin Profile": "অ্যাডমিন প্রোফাইল",
+    "Dashboard": "ড্যাশবোর্ড",
+    "Log Out": "লগ আউট",
+    "Registration successful. Please log in.": "রেজিস্ট্রেশন সফল হয়েছে। লগইন করুন।",
+    "Invalid credentials.": "ভুল তথ্য প্রদান করা হয়েছে।"
+}

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -1,0 +1,16 @@
+{
+    "Admin Login": "Admin Login",
+    "Email": "Email",
+    "Password": "Password",
+    "Log in": "Log in",
+    "Admin Register": "Admin Register",
+    "Register": "Register",
+    "Admin Dashboard": "Admin Dashboard",
+    "You're logged in as admin!": "You're logged in as admin!",
+    "View Profile": "View Profile",
+    "Admin Profile": "Admin Profile",
+    "Dashboard": "Dashboard",
+    "Log Out": "Log Out",
+    "Registration successful. Please log in.": "Registration successful. Please log in.",
+    "Invalid credentials.": "Invalid credentials."
+}

--- a/resources/views/admin/dashboard.blade.php
+++ b/resources/views/admin/dashboard.blade.php
@@ -8,8 +8,9 @@
     <div class="py-12">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
             <div class="bg-white/70 overflow-hidden shadow-xl sm:rounded-lg backdrop-blur">
-                <div class="p-6 text-gray-900">
-                    You're logged in as admin!
+                <div class='p-6 text-gray-900'>
+                    {{ __("You're logged in as admin!") }}
+                    <a href='{{ route('admin.profile') }}' class='text-blue-600 underline ml-2'>{{ __('View Profile') }}</a>
                 </div>
             </div>
         </div>

--- a/resources/views/admin/login.blade.php
+++ b/resources/views/admin/login.blade.php
@@ -1,5 +1,5 @@
 @extends('layouts.front')
-@section('title','Admin Login')
+@section('title', __('Admin Login'))
 
 @push('styles')
 <link rel="stylesheet" href="{{ asset('assets/css/auth.css') }}">
@@ -8,7 +8,7 @@
 @section('content')
 <div class="container">
     <div class="form-container">
-        <h2 class="mb-4 text-center">Admin Login</h2>
+        <h2 class="mb-4 text-center">{{ __('Admin Login') }}</h2>
 
         @if ($errors->any())
             <div class="alert alert-danger">
@@ -23,15 +23,15 @@
         <form method="POST" action="{{ url('/admin/login') }}">
             @csrf
             <div class="mb-3">
-                <label for="email" class="form-label">Email</label>
+                <label for="email" class="form-label">{{ __('Email') }}</label>
                 <input id="email" class="form-control" type="email" name="email" required autofocus>
             </div>
             <div class="mb-3">
-                <label for="password" class="form-label">Password</label>
+                <label for="password" class="form-label">{{ __('Password') }}</label>
                 <input id="password" class="form-control" type="password" name="password" required>
             </div>
             <div class="d-flex justify-content-end">
-                <button class="btn btn-primary" type="submit">Log in</button>
+                <button class="btn btn-primary" type="submit">{{ __('Log in') }}</button>
             </div>
         </form>
     </div>

--- a/resources/views/admin/profile.blade.php
+++ b/resources/views/admin/profile.blade.php
@@ -1,0 +1,16 @@
+<x-app-layout>
+    <x-slot name='header'>
+        <h2 class='font-semibold text-xl text-gray-800 leading-tight'>
+            {{ __('Admin Profile') }}
+        </h2>
+    </x-slot>
+
+    <div class='py-12'>
+        <div class='max-w-7xl mx-auto sm:px-6 lg:px-8'>
+            <div class='bg-white/70 overflow-hidden shadow-xl sm:rounded-lg backdrop-blur p-6'>
+                <p><strong>{{ __('Email') }}:</strong> {{ $admin['email'] }}</p>
+            </div>
+        </div>
+    </div>
+</x-app-layout>
+

--- a/resources/views/admin/register.blade.php
+++ b/resources/views/admin/register.blade.php
@@ -1,5 +1,5 @@
 @extends('layouts.front')
-@section('title','Admin Register')
+@section('title', __('Admin Register'))
 
 @push('styles')
 <link rel="stylesheet" href="{{ asset('assets/css/auth.css') }}">
@@ -8,7 +8,7 @@
 @section('content')
 <div class="container">
     <div class="form-container">
-        <h2 class="mb-4 text-center">Admin Register</h2>
+        <h2 class="mb-4 text-center">{{ __('Admin Register') }}</h2>
 
         @if ($errors->any())
             <div class="alert alert-danger">
@@ -23,15 +23,15 @@
         <form method="POST" action="{{ url('/admin/register') }}">
             @csrf
             <div class="mb-3">
-                <label for="email" class="form-label">Email</label>
+                <label for="email" class="form-label">{{ __('Email') }}</label>
                 <input id="email" class="form-control" type="email" name="email" required autofocus>
             </div>
             <div class="mb-3">
-                <label for="password" class="form-label">Password</label>
+                <label for="password" class="form-label">{{ __('Password') }}</label>
                 <input id="password" class="form-control" type="password" name="password" required>
             </div>
             <div class="d-flex justify-content-end">
-                <button class="btn btn-primary" type="submit">Register</button>
+                <button class="btn btn-primary" type="submit">{{ __('Register') }}</button>
             </div>
         </form>
     </div>

--- a/resources/views/components/lang-switcher.blade.php
+++ b/resources/views/components/lang-switcher.blade.php
@@ -1,0 +1,4 @@
+<div {{ $attributes->merge(['class' => 'flex space-x-2']) }}>
+    <a href="{{ route('lang.switch', 'en') }}" class="text-sm {{ app()->getLocale() === 'en' ? 'font-bold underline' : '' }}">English</a>
+    <a href="{{ route('lang.switch', 'bn') }}" class="text-sm {{ app()->getLocale() === 'bn' ? 'font-bold underline' : '' }}">বাংলা</a>
+</div>

--- a/resources/views/layouts/front.blade.php
+++ b/resources/views/layouts/front.blade.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -11,6 +11,9 @@
     @stack('styles')
 </head>
 <body>
+    <div class="p-4 text-right">
+        <x-lang-switcher class="inline-flex" />
+    </div>
     @yield('content')
 
     <script src="{{ asset('assets/js/vendor/jquery-3.6.2.min.js') }}"></script>

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -20,6 +20,8 @@
 
             <!-- Settings Dropdown -->
             <div class="hidden sm:flex sm:items-center sm:ml-6">
+                <x-lang-switcher class="mr-4" />
+
                 <x-dropdown align="right" width="48">
                     <x-slot name="trigger">
                         <button class="flex items-center text-sm font-medium text-gray-500 hover:text-gray-700 hover:border-gray-300 focus:outline-none focus:text-gray-700 focus:border-gray-300 transition duration-150 ease-in-out">
@@ -76,6 +78,8 @@
             </div>
 
             <div class="mt-3 space-y-1">
+                <x-lang-switcher class="px-4" />
+
                 <!-- Authentication -->
                 <form method="POST" action="{{ route('logout') }}">
                     @csrf

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\AdminController;
+use App\Http\Controllers\LanguageController;
 
 /*
 |--------------------------------------------------------------------------
@@ -27,8 +28,11 @@ Route::prefix('admin')->group(function () {
     Route::get('/register', [AdminController::class, 'showRegister'])->name('admin.register');
     Route::post('/register', [AdminController::class, 'register']);
     Route::get('/dashboard', [AdminController::class, 'dashboard'])->name('admin.dashboard');
+    Route::get('/profile', [AdminController::class, 'profile'])->name('admin.profile');
     Route::post('/logout', [AdminController::class, 'logout'])->name('admin.logout');
 });
+
+Route::get('/lang/{locale}', [LanguageController::class, 'switch'])->name('lang.switch');
 
 Route::view('/', 'welcome');
 


### PR DESCRIPTION
## Summary
- add profile route and controller logic for admins
- create simple admin profile view and link from dashboard
- enable bilingual browsing with English and Bangla translations

## Testing
- `composer install` *(fails: inertiajs/inertia-laravel requires php ^7.2|~8.0.0|~8.1.0 and other packages require <8.3)*
- `php artisan test` *(fails: Failed opening required '/workspace/firstone/vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_b_68aff681c78c832da8c09ac67209dfb0