### PR TITLE
Add animated background and feature section to home page

### DIFF
--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -3938,3 +3938,22 @@ ul.accordion ul li a span {
     bottom: 0;
     z-index: 9991;
 }
+
+/* Home animated background */
+.animated-bg {
+    background: linear-gradient(-45deg, #ee7752, #e73c7e, #23a6d5, #23d5ab);
+    background-size: 400% 400%;
+    animation: gradientBG 15s ease infinite;
+}
+
+@keyframes gradientBG {
+    0% {
+        background-position: 0% 50%;
+    }
+    50% {
+        background-position: 100% 50%;
+    }
+    100% {
+        background-position: 0% 50%;
+    }
+}

--- a/resources/views/layouts/front.blade.php
+++ b/resources/views/layouts/front.blade.php
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="{{ asset('assets/css/responsive.css') }}">
     @stack('styles')
 </head>
-<body>
+<body class="@yield('body-class')">
     <div class="p-4 text-right">
         <x-lang-switcher class="inline-flex" />
     </div>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -1,6 +1,7 @@
 @extends('layouts.front')
 
 @section('title', 'Welcome')
+@section('body-class', 'animated-bg')
 
 @section('content')
 <header class="header-area">
@@ -18,6 +19,32 @@
     <div class="container">
         <h1>Welcome</h1>
         <p class="lead">This page uses template assets.</p>
+        <a href="#" class="btn btn-primary mt-3">Get Started</a>
+    </div>
+</section>
+
+<section class="features-section py-5 text-center">
+    <div class="container">
+        <div class="row">
+            <div class="col-md-4 mb-4">
+                <div class="p-4 shadow-sm bg-white rounded">
+                    <h3>Fast</h3>
+                    <p>Experience blazing fast performance.</p>
+                </div>
+            </div>
+            <div class="col-md-4 mb-4">
+                <div class="p-4 shadow-sm bg-white rounded">
+                    <h3>Secure</h3>
+                    <p>Your data is protected with industry-leading security.</p>
+                </div>
+            </div>
+            <div class="col-md-4 mb-4">
+                <div class="p-4 shadow-sm bg-white rounded">
+                    <h3>Reliable</h3>
+                    <p>Always available when you need it.</p>
+                </div>
+            </div>
+        </div>
     </div>
 </section>
 @endsection


### PR DESCRIPTION
## Summary
- enable pages to set custom `body` classes from front layout
- add animated gradient background and feature cards to welcome page
- define `animated-bg` styles and keyframes

## Testing
- ⚠️ `php artisan test` *(missing vendor dependencies; composer install failed: requires GitHub token)*

------
https://chatgpt.com/codex/tasks/task_b_68affc8aee74832dbd8cc53d9abcc00e