### PR TITLE
Add simple Node.js admin dashboard example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/node_modules
+node_modules/
 /public/hot
 /public/storage
 /storage/*.key

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "admin-panel",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "admin-panel",
+      "version": "1.0.0"
+    }
+  }
+}

--- a/admin/package.json
+++ b/admin/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "admin-panel",
+  "version": "1.0.0",
+  "description": "Simple Node.js admin panel demo",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "echo \"No tests specified\" && exit 0"
+  },
+  "dependencies": {}
+}

--- a/admin/public/index.html
+++ b/admin/public/index.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Podcast Dashboard</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100 p-6">
+  <div class="max-w-6xl mx-auto bg-white p-6 rounded-lg shadow">
+    <h1 class="text-2xl font-semibold mb-4">Podcast Dashboard</h1>
+    <div class="overflow-x-auto">
+      <table class="min-w-full divide-y divide-gray-200">
+        <thead>
+          <tr>
+            <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Podcast Name</th>
+            <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Duration</th>
+            <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Category</th>
+            <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Latest Episode</th>
+            <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Average Duration</th>
+            <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
+          </tr>
+        </thead>
+        <tbody class="bg-white divide-y divide-gray-200">
+          <tr>
+            <td class="px-4 py-2 whitespace-nowrap">Mindful Wanderers</td>
+            <td class="px-4 py-2">45 mins</td>
+            <td class="px-4 py-2"><span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-blue-100 text-blue-800">Travel</span></td>
+            <td class="px-4 py-2">Ep 120: The Journey Within</td>
+            <td class="px-4 py-2">40 mins</td>
+            <td class="px-4 py-2"><a href="#" class="text-indigo-600 hover:text-indigo-900">Edit</a></td>
+          </tr>
+          <tr>
+            <td class="px-4 py-2 whitespace-nowrap">Science Explained</td>
+            <td class="px-4 py-2">30 mins</td>
+            <td class="px-4 py-2"><span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800">Science</span></td>
+            <td class="px-4 py-2">Ep 45: Quantum Realities</td>
+            <td class="px-4 py-2">32 mins</td>
+            <td class="px-4 py-2"><a href="#" class="text-indigo-600 hover:text-indigo-900">Edit</a></td>
+          </tr>
+          <tr>
+            <td class="px-4 py-2 whitespace-nowrap">Business Buzz</td>
+            <td class="px-4 py-2">50 mins</td>
+            <td class="px-4 py-2"><span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-purple-100 text-purple-800">Finance</span></td>
+            <td class="px-4 py-2">Ep 30: Market Trends</td>
+            <td class="px-4 py-2">48 mins</td>
+            <td class="px-4 py-2"><a href="#" class="text-indigo-600 hover:text-indigo-900">Edit</a></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</body>
+</html>

--- a/admin/server.js
+++ b/admin/server.js
@@ -1,0 +1,25 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const PORT = process.env.PORT || 3000;
+const publicDir = path.join(__dirname, 'public');
+
+const server = http.createServer((req, res) => {
+  const filePath = path.join(publicDir, req.url === '/' ? 'index.html' : req.url);
+  fs.readFile(filePath, (err, content) => {
+    if (err) {
+      res.writeHead(404, { 'Content-Type': 'text/plain' });
+      res.end('Not Found');
+    } else {
+      const ext = path.extname(filePath).toLowerCase();
+      const type = ext === '.html' ? 'text/html' : 'text/plain';
+      res.writeHead(200, { 'Content-Type': type });
+      res.end(content);
+    }
+  });
+});
+
+server.listen(PORT, () => {
+  console.log(`Admin panel available at http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add Node.js demo server serving static admin dashboard
- include Tailwind-powered table layout mimicking podcast dashboard
- ignore nested node_modules directories

## Testing
- `node admin/server.js` *(runs and then terminated)*
- `npm test --prefix admin`
- `phpunit` *(fails: command not found)*
- `php artisan test` *(fails: missing vendor/autoload.php)*

------
https://chatgpt.com/codex/tasks/task_b_68b0038b1c20832d8b390a69dbb167cf