### PR TITLE
Enhance admin dashboard with dynamic podcast data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/node_modules
+node_modules/
 /public/hot
 /public/storage
 /storage/*.key

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "admin-panel",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "admin-panel",
+      "version": "1.0.0"
+    }
+  }
+}

--- a/admin/package.json
+++ b/admin/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "admin-panel",
+  "version": "1.0.0",
+  "description": "Simple Node.js admin panel demo",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "echo \"No tests specified\" && exit 0"
+  },
+  "dependencies": {}
+}

--- a/admin/public/app.js
+++ b/admin/public/app.js
@@ -1,0 +1,23 @@
+const colorMap = {
+  Travel: 'bg-blue-100 text-blue-800',
+  Science: 'bg-green-100 text-green-800',
+  Finance: 'bg-purple-100 text-purple-800'
+};
+
+fetch('/api/podcasts')
+  .then(res => res.json())
+  .then(data => {
+    const tbody = document.getElementById('podcast-table-body');
+    data.forEach(p => {
+      const tr = document.createElement('tr');
+      tr.innerHTML = `
+        <td class="px-4 py-2 whitespace-nowrap">${p.name}</td>
+        <td class="px-4 py-2">${p.duration}</td>
+        <td class="px-4 py-2"><span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full ${colorMap[p.category] || 'bg-gray-100 text-gray-800'}">${p.category}</span></td>
+        <td class="px-4 py-2">${p.latest}</td>
+        <td class="px-4 py-2">${p.avg}</td>
+        <td class="px-4 py-2"><a href="#" class="text-indigo-600 hover:text-indigo-900">Edit</a></td>
+      `;
+      tbody.appendChild(tr);
+    });
+  });

--- a/admin/public/index.html
+++ b/admin/public/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Podcast Dashboard</title>
+  <link rel="stylesheet" href="styles.css" />
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100 p-6">
+  <div class="max-w-6xl mx-auto bg-white p-6 rounded-lg shadow">
+    <h1 class="text-2xl font-semibold mb-4">Podcast Dashboard</h1>
+    <div class="overflow-x-auto">
+      <table class="min-w-full divide-y divide-gray-200">
+        <thead>
+          <tr>
+            <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Podcast Name</th>
+            <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Duration</th>
+            <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Category</th>
+            <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Latest Episode</th>
+            <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Average Duration</th>
+            <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
+          </tr>
+        </thead>
+        <tbody id="podcast-table-body" class="bg-white divide-y divide-gray-200"></tbody>
+      </table>
+    </div>
+  </div>
+</body>
+<script src="app.js"></script>
+</html>

--- a/admin/public/styles.css
+++ b/admin/public/styles.css
@@ -1,0 +1,3 @@
+body {
+  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+}

--- a/admin/server.js
+++ b/admin/server.js
@@ -1,0 +1,37 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const PORT = process.env.PORT || 3000;
+const publicDir = path.join(__dirname, 'public');
+
+const podcasts = [
+  { name: 'Mindful Wanderers', duration: '45 mins', category: 'Travel', latest: 'Ep 120: The Journey Within', avg: '40 mins' },
+  { name: 'Science Explained', duration: '30 mins', category: 'Science', latest: 'Ep 45: Quantum Realities', avg: '32 mins' },
+  { name: 'Business Buzz', duration: '50 mins', category: 'Finance', latest: 'Ep 30: Market Trends', avg: '48 mins' }
+];
+
+const server = http.createServer((req, res) => {
+  if (req.url === '/api/podcasts') {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    return res.end(JSON.stringify(podcasts));
+  }
+
+  const filePath = path.join(publicDir, req.url === '/' ? 'index.html' : req.url);
+  fs.readFile(filePath, (err, content) => {
+    if (err) {
+      res.writeHead(404, { 'Content-Type': 'text/plain' });
+      res.end('Not Found');
+    } else {
+      const ext = path.extname(filePath).toLowerCase();
+      const types = { '.html': 'text/html', '.js': 'application/javascript', '.css': 'text/css' };
+      const type = types[ext] || 'text/plain';
+      res.writeHead(200, { 'Content-Type': type });
+      res.end(content);
+    }
+  });
+});
+
+server.listen(PORT, () => {
+  console.log(`Admin panel available at http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- expose `/api/podcasts` endpoint serving sample data
- load dashboard table dynamically via client-side script
- include basic styling assets for admin panel

## Testing
- `node admin/server.js`
- `npm test --prefix admin`
- `composer install` *(fails: lock file out of date)*
- `phpunit` *(fails: command not found)*
- `php artisan test` *(fails: missing vendor/autoload.php)*

------
https://chatgpt.com/codex/tasks/task_b_68b0038b1c20832d8b390a69dbb167cf